### PR TITLE
Rewrite parseEnglishPattern, adding stricter checks for the format

### DIFF
--- a/cadence.go
+++ b/cadence.go
@@ -5,32 +5,31 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/robfig/cron"
 )
 
 var cronParser = cron.NewParser(cron.Second | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.DowOptional | cron.Descriptor)
 
-type interval string
+type timeUnit string
 
 const (
-	second = interval("second")
-	minute = interval("minute")
-	hour   = interval("hour")
-	day    = interval("day")
-	week   = interval("week")
-	month  = interval("month")
-	year   = interval("year")
+	second = timeUnit("second")
+	minute = timeUnit("minute")
+	hour   = timeUnit("hour")
+	day    = timeUnit("day")
+	week   = timeUnit("week")
+	month  = timeUnit("month")
+	year   = timeUnit("year")
 )
 
 type englishPattern struct {
 	Number   int
-	Interval interval
+	TimeUnit timeUnit
 }
 
 func (e englishPattern) ToCrontab() string {
-	switch e.Interval {
+	switch e.TimeUnit {
 	case second:
 		return fmt.Sprintf("*/%d * * * * *", e.Number)
 	case minute:
@@ -49,42 +48,34 @@ func (e englishPattern) ToCrontab() string {
 }
 
 func parseEnglishPattern(pattern string) (*englishPattern, error) {
-	orig := pattern
-	pattern = strings.TrimSpace(pattern)
-	pattern = strings.ToLower(pattern)
-
-	if !strings.HasPrefix(pattern, "every") {
-		return nil, fmt.Errorf("invalid prefix for pattern `%s`", orig)
-	}
-
-	// there should be a number as the next character.
-	pattern = strings.TrimPrefix(pattern, "every")
-	pattern = strings.TrimSpace(pattern)
-
-	var bld strings.Builder
-
-	for _, r := range pattern {
-		if unicode.IsDigit(r) {
-			bld.WriteRune(r)
-		} else {
-			break
-		}
-	}
-
-	i, _ := strconv.Atoi(bld.String())
-
+	var tokens []string = strings.Fields(pattern)
 	var num int
+	var tUnit timeUnit
+	var timeUnitToken string
 
-	if i == 0 {
+	// structure sanity check. There should be 3 tokens (or 2 if a "1" is implied)
+	// in the form of "every <number> <time unit>".
+	// We need to parse the number if it exists and retrieve the time unit.
+	if len(tokens) == 3 {
+		if n, err := strconv.Atoi(tokens[1]); err != nil {
+			return nil, fmt.Errorf("invalid pattern: `%s` cannot be parsed as a number", tokens[1])
+		} else {
+			num = n
+			timeUnitToken = tokens[2]
+		}
+	} else if len(tokens) == 2 {
+		//there is no number so 1 is implied. Time unit should be the second token
 		num = 1
+		timeUnitToken = tokens[1]
 	} else {
-		num = i
+		return nil, fmt.Errorf("invalid number of tokens for pattern `%s`, expecting 2 or 3 tokens, got %d", pattern, len(tokens))
 	}
 
-	pattern = strings.TrimLeftFunc(pattern, unicode.IsDigit)
-	pattern = strings.TrimSpace(pattern)
+	if tokens[0] != "every" {
+		return nil, fmt.Errorf("invalid prefix for pattern `%s`, all patterns must start with \"every\"", pattern)
+	}
 
-	suffixes := map[string]interval{
+	timeUnits := map[string]timeUnit{
 		"second":  second,
 		"seconds": second,
 		"minute":  minute,
@@ -101,14 +92,26 @@ func parseEnglishPattern(pattern string) (*englishPattern, error) {
 		"years":   year,
 	}
 
-	if i, ok := suffixes[pattern]; ok {
-		return &englishPattern{
-			Number:   num,
-			Interval: i,
-		}, nil
+	if unit, ok := timeUnits[timeUnitToken]; !ok {
+		return nil, fmt.Errorf("invalid time unit `%s` for pattern `%s`", timeUnitToken, pattern)
+	} else if num == 1 && isPlural(timeUnitToken) {
+		// user supplied sth like "every (1) months", probable bug on their side, reject it.
+		return nil, fmt.Errorf("invalid number and time unit combination. Number is 1 and time unit is in plural")
+	} else if num > 1 && !isPlural(timeUnitToken) {
+		// the inverse of before
+		return nil, fmt.Errorf("invalid number and time unit combination. Number is > 1 and time unit is in singular")
 	} else {
-		return nil, fmt.Errorf("couldn't define interval for patten `%s`", orig)
+		tUnit = unit
 	}
+
+	return &englishPattern{
+		Number:   num,
+		TimeUnit: tUnit,
+	}, nil
+}
+
+func isPlural(s string) bool {
+	return strings.HasSuffix(s, "s")
 }
 
 func isValidEnglishPattern(pattern string) bool {

--- a/cadence.go
+++ b/cadence.go
@@ -48,7 +48,8 @@ func (e englishPattern) ToCrontab() string {
 }
 
 func parseEnglishPattern(pattern string) (*englishPattern, error) {
-	var tokens []string = strings.Fields(pattern)
+	pattern = strings.ToLower(pattern) // case insensitive
+	tokens := strings.Fields(pattern)
 	var num int
 	var tUnit timeUnit
 	var timeUnitToken string

--- a/cadence.go
+++ b/cadence.go
@@ -23,12 +23,12 @@ const (
 	year   = timeUnit("year")
 )
 
-type englishPattern struct {
+type interval struct {
 	Number   int
 	TimeUnit timeUnit
 }
 
-func (e englishPattern) ToCrontab() string {
+func (e interval) ToCrontab() string {
 	switch e.TimeUnit {
 	case second:
 		return fmt.Sprintf("*/%d * * * * *", e.Number)
@@ -47,7 +47,7 @@ func (e englishPattern) ToCrontab() string {
 	}
 }
 
-func parseEnglishPattern(pattern string) (*englishPattern, error) {
+func parseEnglishPattern(pattern string) (*interval, error) {
 	pattern = strings.ToLower(pattern) // case insensitive
 	tokens := strings.Fields(pattern)
 	var num int
@@ -105,7 +105,7 @@ func parseEnglishPattern(pattern string) (*englishPattern, error) {
 		tUnit = unit
 	}
 
-	return &englishPattern{
+	return &interval{
 		Number:   num,
 		TimeUnit: tUnit,
 	}, nil

--- a/cadence_test.go
+++ b/cadence_test.go
@@ -87,10 +87,55 @@ func TestNext(t *testing.T) {
 }
 
 func TestParseEnglishPattern(t *testing.T) {
-	spec, err := parseEnglishPattern("every 1 hour")
-	require.NoError(t, err)
-	assert.Equal(t, 1, spec.Number)
-	assert.Equal(t, hour, spec.Interval)
+	t.Run("general case", func(t *testing.T) {
+		spec, err := parseEnglishPattern("every 2 years")
+		require.NoError(t, err)
+		assert.Equal(t, 2, spec.Number)
+		assert.Equal(t, year, spec.TimeUnit)
+	})
+
+	t.Run("pattern too short", func(t *testing.T) {
+		_, err := parseEnglishPattern("every ")
+		require.Error(t, err)
+	})
+
+	t.Run("pattern too long", func(t *testing.T) {
+		_, err := parseEnglishPattern("every 5 years now!")
+		require.Error(t, err)
+	})
+
+	t.Run("pattern with an implicit 1", func(t *testing.T) {
+		spec, err := parseEnglishPattern("every month")
+		require.NoError(t, err)
+		assert.Equal(t, 1, spec.Number)
+		assert.Equal(t, month, spec.TimeUnit)
+	})
+
+	t.Run("pattern with 1 and time unit in plural", func(t *testing.T) {
+		_, err := parseEnglishPattern("every 1 weeks")
+		require.Error(t, err)
+	})
+
+	t.Run("pattern with > 1 and time unit in singular", func(t *testing.T) {
+		_, err := parseEnglishPattern("every 2 month")
+		require.Error(t, err)
+	})
+
+	t.Run("pattern with invalid number", func(t *testing.T) {
+		_, err := parseEnglishPattern("every something months")
+		require.Error(t, err)
+	})
+
+	t.Run("pattern with malformed number", func(t *testing.T) {
+		_, err := parseEnglishPattern("every 2s months")
+		require.Error(t, err)
+	})
+
+	t.Run("pattern not starting with every", func(t *testing.T) {
+		_, err := parseEnglishPattern("1 year every")
+		require.Error(t, err)
+	})
+
 }
 
 func MustParse(t *testing.T, str string) time.Time {

--- a/cadence_test.go
+++ b/cadence_test.go
@@ -136,6 +136,13 @@ func TestParseEnglishPattern(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("pattern with uppercase characters", func(t *testing.T) {
+		spec, err := parseEnglishPattern("Every 5 Weeks")
+		require.NoError(t, err)
+		assert.Equal(t, 5, spec.Number)
+		assert.Equal(t, week, spec.TimeUnit)
+	})
+
 }
 
 func MustParse(t *testing.T, str string) time.Time {


### PR DESCRIPTION
This PR rewrites the parseEnglishPattern function to be more explicit in checks, working on a set of tokens (word of the natural language pattern provide).
It also makes the syntax more strict to avoid mismatches in 1 and plural time units or the inverse, numbers >1 with a singular time unit. Those are either harmeless typos or bugs on the users side.

Added a bunch of tests as well.

Testing:
```
Running tool: /usr/local/go/bin/go test -timeout 30s -run ^TestParseEnglishPattern$ github.com/bradhe/cadence

=== RUN   TestParseEnglishPattern
=== RUN   TestParseEnglishPattern/general_case
--- PASS: TestParseEnglishPattern/general_case (0.00s)
=== RUN   TestParseEnglishPattern/pattern_too_short
--- PASS: TestParseEnglishPattern/pattern_too_short (0.00s)
=== RUN   TestParseEnglishPattern/pattern_too_long
--- PASS: TestParseEnglishPattern/pattern_too_long (0.00s)
=== RUN   TestParseEnglishPattern/pattern_with_an_implicit_1
--- PASS: TestParseEnglishPattern/pattern_with_an_implicit_1 (0.00s)
=== RUN   TestParseEnglishPattern/pattern_with_1_and_time_unit_in_plural
--- PASS: TestParseEnglishPattern/pattern_with_1_and_time_unit_in_plural (0.00s)
=== RUN   TestParseEnglishPattern/pattern_with_>_1_and_time_unit_in_singular
--- PASS: TestParseEnglishPattern/pattern_with_>_1_and_time_unit_in_singular (0.00s)
=== RUN   TestParseEnglishPattern/pattern_with_invalid_number
--- PASS: TestParseEnglishPattern/pattern_with_invalid_number (0.00s)
=== RUN   TestParseEnglishPattern/pattern_with_malformed_number
--- PASS: TestParseEnglishPattern/pattern_with_malformed_number (0.00s)
=== RUN   TestParseEnglishPattern/pattern_not_starting_with_every
--- PASS: TestParseEnglishPattern/pattern_not_starting_with_every (0.00s)
--- PASS: TestParseEnglishPattern (0.00s)
PASS
ok      github.com/bradhe/cadence       0.008s
```